### PR TITLE
fix delivery.js

### DIFF
--- a/app/assets/javascripts/delivery.js
+++ b/app/assets/javascripts/delivery.js
@@ -78,7 +78,9 @@ $(function(){
         }
      
     }else{
-      $('#delivery-way').remove(); 
+      $('#delevery-way-title-box').remove();
+      $('#delevery-way-select-box').remove();
+      $('.delivery-burden').append(deliverywayHtml);
     };
   
   });


### PR DESCRIPTION
# What

商品登録の配送方法を選ぶ際に、商品負担の選択を---にしても配送方法の選択肢が画面から消えないバグを修正しました。